### PR TITLE
Add dev container & related changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # qmstr-container
 Container to run the qmstr
+
+## Build the containers
+`./build.sh`
+
+Will result in qmstr/master & qmstr/dev
+
+## Run the qmstr master for production (not there yet)
+`docker run -p 50051:50051 -v <build_path>:/buildroot qmstr/master`
+
+## Run master for development
+`docker run --rm -p 50051:50051 -p 8081:8081 -p 8080:8080 -v $(pwd):/go/src/github.com/QMSTR/qmstr -v <build_path>:/buildroot qmstr/dev`
+
+Assuming pwd is qmstr src dir

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+docker build -t qmstr/master master
+docker build -t qmstr/dev dev

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:17.10
+
+ENV GOPATH /go
+ENV PATH ${GOPATH}/bin:/usr/lib/go-1.9/bin:$PATH
+
+# install golang 1.9
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:gophers/archive && \
+    apt-get update && \
+    apt-get install -y curl golang-1.9-go autoconf git libio-captureoutput-perl python python-pip protobuf-compiler && \
+    rm -rf /var/lib/apt/lists/*
+
+# install ninka
+RUN mkdir /ninka && \
+    git clone https://github.com/dmgerman/ninka.git /ninka && \
+    cd /ninka/comments && make && make install && \
+    rm /usr/local/man/man1 && \
+    cd /ninka && perl Makefile.PL && make && make install && \
+    rm -fr /ninka
+
+# install scancode
+RUN pip install scancode-toolkit
+
+# install dgraph
+RUN curl https://get.dgraph.io -sSf | bash
+
+# install go deps
+RUN go get -u github.com/golang/protobuf/protoc-gen-go && \
+    go get github.com/dgraph-io/dgraph/client
+
+EXPOSE 50051
+# dgraph ratel web ui
+EXPOSE 8081
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -6,7 +6,16 @@ function start_dgraph() {
     dgraph server --memory_mb=2048 --zero=localhost:5080 &
 }
 
+function start_dgraph_web {
+    dgraph-ratel &
+}
+
+# Generate and build
+go generate github.com/QMSTR/qmstr/cmd/qmstr-master
+go install github.com/QMSTR/qmstr/cmd/qmstr-master
+
 start_dgraph
+start_dgraph_web
 
 # Give dgraph some time to come up
 sleep 15


### PR DESCRIPTION
The initial implementation pulled the golang src from github master.
This makes it difficult to test local uncommited, unmerged changes. This
change removes the dev flag from the 'master' container and introduces a
new 'dev' container.

The dev container builds qmstr binaries from source mounted as a volume
in the container on runtime. So it's meant to be invoked for testing
local changes. See updated README.md for example.

Also a build.sh script was added to save some milliseconds :)